### PR TITLE
Reset all config values when starting the gametest server

### DIFF
--- a/src/main/java/ca/fxco/gametestlib/GameTestLibMod.java
+++ b/src/main/java/ca/fxco/gametestlib/GameTestLibMod.java
@@ -48,6 +48,7 @@ public class GameTestLibMod implements ModInitializer {
 
             ServerLifecycleEvents.SERVER_STARTED.register(server -> {
                 CURRENT_SERVER = server;
+                CONFIG_MANAGER.resetAllValues();
             });
 
             GameTestBlocks.boostrap();

--- a/src/main/java/ca/fxco/gametestlib/config/ConfigManager.java
+++ b/src/main/java/ca/fxco/gametestlib/config/ConfigManager.java
@@ -33,4 +33,10 @@ public class ConfigManager {
         return Optional.empty();
     }
 
+    /**
+     * Resets all values to their default value
+     */
+    public void resetAllValues() {
+        this.values.forEach((s, v) -> v.setDefault());
+    }
 }


### PR DESCRIPTION
`ServerLifecycleEvents.SERVER_STARTED` runs after our mixin in PistonLib. So it will only reset the config value once its been loaded